### PR TITLE
Add settings menu to change the 3d model viewer gestures with

### DIFF
--- a/Flagrum.Desktop/App.xaml.cs
+++ b/Flagrum.Desktop/App.xaml.cs
@@ -47,13 +47,15 @@ public partial class App
         context.Database.MigrateAsync().Wait();
 
         // Set default key bindings for 3D viewer
-        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportRotateGesture))
+        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportRotateModifierKey))
         {
-            context.SetString(StateKey.ViewportRotateGesture, "MiddleClick");
+            context.SetString(StateKey.ViewportRotateModifierKey, "None");
+            context.SetString(StateKey.ViewportRotateMouseAction, "MiddleClick");
         }
-        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportPanGesture))
+        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportPanModifierKey))
         {
-            context.SetString(StateKey.ViewportPanGesture, "Shift+MiddleClick");
+            context.SetString(StateKey.ViewportPanModifierKey, "Shift");
+            context.SetString(StateKey.ViewportPanMouseAction, "MiddleClick");
         }
 
         // Set culture based on stored language settings if any

--- a/Flagrum.Desktop/App.xaml.cs
+++ b/Flagrum.Desktop/App.xaml.cs
@@ -1,15 +1,16 @@
-﻿using System;
+﻿using Flagrum.Web.Persistence;
+using Flagrum.Web.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Squirrel;
+using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
-using Flagrum.Web.Persistence;
-using Flagrum.Web.Persistence.Entities;
-using Microsoft.EntityFrameworkCore;
-using Squirrel;
 
 namespace Flagrum.Desktop;
 
@@ -40,10 +41,20 @@ public partial class App
         SquirrelAwareApp.HandleEvents(
             OnInstall,
             onAppUninstall: OnUninstall);
-        
+
         // Migrate the database if required
         using var context = new FlagrumDbContext();
         context.Database.MigrateAsync().Wait();
+
+        // Set default key bindings for 3D viewer
+        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportRotateGesture))
+        {
+            context.SetString(StateKey.ViewportRotateGesture, "MiddleClick");
+        }
+        if (!context.StatePairs.Any(p => p.Key == StateKey.ViewportPanGesture))
+        {
+            context.SetString(StateKey.ViewportPanGesture, "Shift+MiddleClick");
+        }
 
         // Set culture based on stored language settings if any
         var cultureName = context.GetString(StateKey.Language);

--- a/Flagrum.Desktop/AttachedProperties/InputBinding.cs
+++ b/Flagrum.Desktop/AttachedProperties/InputBinding.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+
+namespace Flagrum.Desktop.AttachedProperties
+{
+    public static class InputBinding
+    {
+        /// <summary>Returns the value of the attached property Gesture for the <paramref name="inputBinding"/>.</summary>
+        /// <param name="inputBinding"><see cref="System.Windows.Input.InputBinding"/>  whose property value will be returned.</param>
+        /// <returns>Property value <see cref="InputGesture"/>.</returns>
+        public static InputGesture GetGesture(System.Windows.Input.InputBinding inputBinding)
+        {
+            return (InputGesture)inputBinding.GetValue(GestureProperty);
+        }
+
+        /// <summary>Sets the value of the Gesture attached property to <paramref name="inputBinding"/>.</summary>
+        /// <param name="inputBinding"><see cref="System.Windows.Input.InputBinding"/> whose property is setting to a value..</param>
+        /// <param name="value"><see cref="InputGesture"/> value for property.</param>
+        public static void SetGesture(System.Windows.Input.InputBinding inputBinding, InputGesture value)
+        {
+            inputBinding.SetValue(GestureProperty, value);
+        }
+
+        /// <summary><see cref="DependencyProperty"/> for methods <see cref="GetGesture(System.Windows.Input.InputBinding)"/>
+        /// and <see cref="SetGesture(System.Windows.Input.InputBinding, InputGesture)"/>.</summary>
+        public static readonly DependencyProperty GestureProperty =
+            DependencyProperty.RegisterAttached(
+                nameof(GetGesture).Substring(3),
+                typeof(InputGesture),
+                typeof(InputBinding),
+                new PropertyMetadata(null, OnGestureChanged));
+
+        private static void OnGestureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not System.Windows.Input.InputBinding inputBinding)
+                throw new NotImplementedException($"Implemented only for the \"{typeof(System.Windows.Input.InputBinding).FullName}\" class");
+
+            inputBinding.Gesture = (InputGesture)e.NewValue;
+        }
+    }
+}

--- a/Flagrum.Desktop/MainViewModel.cs
+++ b/Flagrum.Desktop/MainViewModel.cs
@@ -56,46 +56,17 @@ public class MainViewModel : ObservableObject, IDisposable
 
         using var context = new FlagrumDbContext(new SettingsService());
 
-        // TODO improve code quality
+        var viewportRotateModifierKey = context.GetString(StateKey.ViewportRotateModifierKey);
+        var viewportRotateMouseAction = context.GetString(StateKey.ViewportRotateMouseAction);
+        Enum.TryParse(viewportRotateModifierKey, out ModifierKeys rotateModifierKeyEnum);
+        Enum.TryParse(viewportRotateMouseAction, out MouseAction rotateMouseActionEnum);
+        _viewportRotateGesture = new MouseGesture(rotateMouseActionEnum, rotateModifierKeyEnum);
 
-        var stringParts = context.GetString(StateKey.ViewportRotateGesture).Split('+');
-
-        if (stringParts.Length == 2)
-        {
-            Enum.TryParse(stringParts[1], out MouseAction rotateModifierKeyEnum);
-            Enum.TryParse(stringParts[0], out ModifierKeys rotateMouseActionEnum);
-
-            _viewportRotateGesture = new MouseGesture(rotateModifierKeyEnum, rotateMouseActionEnum);
-        }
-        else if (stringParts.Length == 1)
-        {
-            Enum.TryParse(stringParts[0], out MouseAction rotateModifierKeyEnum);
-
-            _viewportRotateGesture = new MouseGesture(rotateModifierKeyEnum);
-        }
-        else
-        {
-            throw new Exception("ViewportRotateGesture contains an invalid length");
-        }
-
-        stringParts = context.GetString(StateKey.ViewportPanGesture).Split('+');
-        if (stringParts.Length == 2)
-        {
-            Enum.TryParse(stringParts[1], out MouseAction panMouseActionEnum);
-            Enum.TryParse(stringParts[0], out ModifierKeys panModifierKeyEnum);
-
-            _viewportPanGesture = new MouseGesture(panMouseActionEnum, panModifierKeyEnum);
-        }
-        else if (stringParts.Length == 1)
-        {
-            Enum.TryParse(stringParts[0], out MouseAction panMouseActionEnum);
-
-            _viewportPanGesture = new MouseGesture(panMouseActionEnum);
-        }
-        else
-        {
-            throw new Exception("ViewportPanGesture contains an invalid length");
-        }
+        var viewportPanModifierKey = context.GetString(StateKey.ViewportPanModifierKey);
+        var viewportPanMouseAction = context.GetString(StateKey.ViewportPanMouseAction);
+        Enum.TryParse(viewportPanModifierKey, out ModifierKeys panModifierKeyEnum);
+        Enum.TryParse(viewportPanMouseAction, out MouseAction panMouseActionEnum);
+        _viewportPanGesture = new MouseGesture(panMouseActionEnum, panModifierKeyEnum);
     }
 
     public ViewportHelper ViewportHelper { get; }

--- a/Flagrum.Desktop/MainViewModel.cs
+++ b/Flagrum.Desktop/MainViewModel.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Windows.Media;
-using System.Windows.Media.Media3D;
-using Flagrum.Desktop.Architecture;
+﻿using Flagrum.Desktop.Architecture;
+using Flagrum.Web.Persistence;
+using Flagrum.Web.Persistence.Entities;
+using Flagrum.Web.Services;
 using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Core.Animations;
 using HelixToolkit.SharpDX.Core.Model.Scene;
 using HelixToolkit.Wpf.SharpDX;
 using HelixToolkit.Wpf.SharpDX.Controls;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
 using Camera = HelixToolkit.Wpf.SharpDX.Camera;
 using Geometry3D = HelixToolkit.SharpDX.Core.Geometry3D;
 using Material = HelixToolkit.Wpf.SharpDX.Material;
@@ -34,6 +38,8 @@ public class MainViewModel : ObservableObject, IDisposable
     private int _viewportLeft = 514;
     private int _viewportTop;
     private int _viewportWidth;
+    private InputGesture _viewportRotateGesture;
+    private InputGesture _viewportPanGesture;
 
     public MainViewModel()
     {
@@ -48,62 +54,48 @@ public class MainViewModel : ObservableObject, IDisposable
             FarPlaneDistance = 10000
         };
 
-        // var builder2 = new MeshBuilder();
-        // builder2.AddSphere(new Vector3(), 2);
-        // Mesh = builder2.ToMesh();
-        // return;
+        using var context = new FlagrumDbContext(new SettingsService());
 
-        // var importer = new Importer();
-        // importer.Configuration.CreateSkeletonForBoneSkinningMesh = true;
-        // importer.Configuration.SkeletonSizeScale = 0.04f;
-        // importer.Configuration.GlobalScale = 0.1f;
-        //
-        // var scene = importer.Load(@"C:\Users\Kieran\Desktop\nh00_010_animated.fbx");
-        // //ModelGroup.AddNode(scene.Root);
-        // BoneSkinMeshNode temp = null;
-        // foreach (var node in scene.Root.Items.Traverse())
-        // {
-        //     if (node is BoneSkinMeshNode {IsSkeletonNode: true} n)
-        //     {
-        //         _armatureNodes.Add(n);
-        //         n.Visible = false;
-        //     }
-        //
-        //     if (node is BoneSkinMeshNode {IsSkeletonNode: false} m)
-        //     {
-        //         if (m.Name == "ShirtShape")
-        //         {
-        //             m.Material = new PBRMaterial
-        //             {
-        //                 AlbedoMap = TextureModel.Create(
-        //                     @"C:\Users\Kieran\Desktop\Models2\nh00\model_010\sourceimages\nh00_010_cloth_00_b_$h.png"),
-        //                 NormalMap = TextureModel.Create(
-        //                     @"C:\Users\Kieran\Desktop\Models2\nh00\model_010\sourceimages\nh00_010_cloth_00_n_$h.png")
-        //             };
-        //
-        //             temp = m;
-        //         }
-        //         else if (m.Name == "bodyShape")
-        //         {
-        //             m.Material = new PBRMaterial
-        //             {
-        //                 // AlbedoMap = TextureModel.Create(
-        //                 //     @"C:\Users\Kieran\Desktop\Models2\nh00\model_010\sourceimages\nh00_010_skin_01_b_$h.png"),
-        //                 // NormalMap = TextureModel.Create(
-        //                 //     @"C:\Users\Kieran\Desktop\Models2\nh00\model_010\sourceimages\nh00_010_skin_01_n_$h.png")
-        //                 AlbedoMap = TextureModel.Create(@"C:\Users\Kieran\Desktop\Cursed\diffuse.png"),
-        //                 NormalMap = TextureModel.Create(@"C:\Users\Kieran\Desktop\Cursed\normal.png")
-        //             };
-        //         }
-        //     }
-        // }
-        //return;
+        // TODO improve code quality
 
+        var stringParts = context.GetString(StateKey.ViewportRotateGesture).Split('+');
 
-        //_animationUpdater = new NodeAnimationUpdater(scene.Animations.First());
+        if (stringParts.Length == 2)
+        {
+            Enum.TryParse(stringParts[1], out MouseAction rotateModifierKeyEnum);
+            Enum.TryParse(stringParts[0], out ModifierKeys rotateMouseActionEnum);
 
+            _viewportRotateGesture = new MouseGesture(rotateModifierKeyEnum, rotateMouseActionEnum);
+        }
+        else if (stringParts.Length == 1)
+        {
+            Enum.TryParse(stringParts[0], out MouseAction rotateModifierKeyEnum);
 
-        //_compositeHelper.Rendering += CompositeHelper_Rendering;
+            _viewportRotateGesture = new MouseGesture(rotateModifierKeyEnum);
+        }
+        else
+        {
+            throw new Exception("ViewportRotateGesture contains an invalid length");
+        }
+
+        stringParts = context.GetString(StateKey.ViewportPanGesture).Split('+');
+        if (stringParts.Length == 2)
+        {
+            Enum.TryParse(stringParts[1], out MouseAction panMouseActionEnum);
+            Enum.TryParse(stringParts[0], out ModifierKeys panModifierKeyEnum);
+
+            _viewportPanGesture = new MouseGesture(panMouseActionEnum, panModifierKeyEnum);
+        }
+        else if (stringParts.Length == 1)
+        {
+            Enum.TryParse(stringParts[0], out MouseAction panMouseActionEnum);
+
+            _viewportPanGesture = new MouseGesture(panMouseActionEnum);
+        }
+        else
+        {
+            throw new Exception("ViewportPanGesture contains an invalid length");
+        }
     }
 
     public ViewportHelper ViewportHelper { get; }
@@ -137,6 +129,18 @@ public class MainViewModel : ObservableObject, IDisposable
     {
         get => _viewportHeight;
         set => SetValue(ref _viewportHeight, value);
+    }
+
+    public InputGesture ViewportRotateGesture
+    {
+        get => _viewportRotateGesture;
+        set => SetValue(ref _viewportRotateGesture, value);
+    }
+
+    public InputGesture ViewportPanGesture
+    {
+        get => _viewportPanGesture;
+        set => SetValue(ref _viewportPanGesture, value);
     }
 
     public bool IsViewportVisible

--- a/Flagrum.Desktop/MainWindow.xaml
+++ b/Flagrum.Desktop/MainWindow.xaml
@@ -207,6 +207,8 @@
                             <helix:Viewport3DX.InputBindings>
                                 <MouseBinding Command="helix:ViewportCommands.Rotate" Gesture="MiddleClick" />
                                 <MouseBinding Command="helix:ViewportCommands.Pan" Gesture="Shift+MiddleClick" />
+                                <MouseBinding Command="helix:ViewportCommands.Rotate" Gesture="LeftClick" />
+                                <MouseBinding Command="helix:ViewportCommands.Pan" Gesture="RightClick" />
                             </helix:Viewport3DX.InputBindings>
                             <helix:DirectionalLight3D Direction="0, -1, -1" Color="White" />
                             <helix:DirectionalLight3D Direction="0, -1, 1" Color="#AAAAAA" />

--- a/Flagrum.Desktop/MainWindow.xaml
+++ b/Flagrum.Desktop/MainWindow.xaml
@@ -11,6 +11,7 @@
         xmlns:fa5="http://schemas.fontawesome.com/icons/"
         xmlns:architecture="clr-namespace:Flagrum.Desktop.Architecture"
         mc:Ignorable="d"
+        xmlns:ap="clr-namespace:Flagrum.Desktop.AttachedProperties"
         Title="Flagrum"
         WindowStartupLocation="CenterScreen"
         ResizeMode="CanResize"
@@ -205,10 +206,8 @@
                                            DefaultCamera="{Binding Camera}"
                                            Initialized="Viewer_OnInitialized">
                             <helix:Viewport3DX.InputBindings>
-                                <MouseBinding Command="helix:ViewportCommands.Rotate" Gesture="MiddleClick" />
-                                <MouseBinding Command="helix:ViewportCommands.Pan" Gesture="Shift+MiddleClick" />
-                                <MouseBinding Command="helix:ViewportCommands.Rotate" Gesture="LeftClick" />
-                                <MouseBinding Command="helix:ViewportCommands.Pan" Gesture="RightClick" />
+                                <MouseBinding Command="helix:ViewportCommands.Rotate" ap:InputBinding.Gesture="{Binding ViewportRotateGesture}" />
+                                <MouseBinding Command="helix:ViewportCommands.Pan" ap:InputBinding.Gesture="{Binding ViewportPanGesture}"  />
                             </helix:Viewport3DX.InputBindings>
                             <helix:DirectionalLight3D Direction="0, -1, -1" Color="White" />
                             <helix:DirectionalLight3D Direction="0, -1, 1" Color="#AAAAAA" />

--- a/Flagrum.Desktop/Services/WpfService.cs
+++ b/Flagrum.Desktop/Services/WpfService.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
-using System.Windows;
-using Flagrum.Web.Services;
+﻿using Flagrum.Web.Services;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.Win32;
 using Microsoft.WindowsAPICodePack.Dialogs;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
 
 namespace Flagrum.Desktop.Services;
 
@@ -90,6 +91,17 @@ public class WpfService : IWpfService
         _mainViewModel.ViewportTop = top;
         _mainViewModel.ViewportWidth = width;
         _mainViewModel.ViewportHeight = height;
+    }
+
+    public void Update3DViewportBindings(string rotateModifierKey, string rotateMouseAction, string panModifierKey, string panMouseAction)
+    {
+        Enum.TryParse(rotateModifierKey, out ModifierKeys rotateModifierKeyEnum);
+        Enum.TryParse(rotateMouseAction, out MouseAction rotateMouseActionEnum);
+        Enum.TryParse(panModifierKey, out ModifierKeys panModifierKeyEnum);
+        Enum.TryParse(panMouseAction, out MouseAction panMouseActionEnum);
+
+        _mainViewModel.ViewportRotateGesture = new MouseGesture(rotateMouseActionEnum, rotateModifierKeyEnum);
+        _mainViewModel.ViewportPanGesture = new MouseGesture(panMouseActionEnum, panModifierKeyEnum);
     }
 
     public void Set3DViewportVisibility(bool isVisible)

--- a/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewSettingsModal.razor
+++ b/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewSettingsModal.razor
@@ -1,0 +1,130 @@
+﻿@using Flagrum.Web.Persistence.Entities
+@using Index = Flagrum.Web.Features.AssetExplorer.Index
+@using Flagrum.Core.Gfxbin.Gmtl.Data
+@using Flagrum.Core.Gfxbin.Data
+@using Flagrum.Core.Gfxbin.Gmtl
+@using System.IO
+@using BinaryReader = Flagrum.Core.Gfxbin.Serialization.BinaryReader
+@using Flagrum.Core.Archive
+@using System.Text
+@inject IWpfService WpfService
+@inject SettingsService Settings
+@inject FlagrumDbContext Context
+@inject AppStateService AppState
+
+<Modal @ref="Modal">
+    <HeaderView>
+        <span class="text-grey-300 flex-grow">Model viewer settings</span>
+        <span class="material-icons cursor-pointer" @onclick="Close">close</span>
+    </HeaderView>
+    <BodyView>
+	    <div class="h-full">
+		    <div class="row">
+			    <label style="width: 250px">Rotate model</label>
+			    <select @bind="RotateModifierKey" class="input bg-dark-550 w-full">
+				    <option>None</option>
+				    <option>Shift</option>
+				    <option>Alt</option>
+			    </select>
+			    <b> + </b>
+			    <select @bind="RotateMouseAction" class="input bg-dark-550 w-full">
+				    <option>None</option>
+				    <option>LeftClick</option>
+				    <option>RightClick</option>
+				    <option>MiddleClick</option>
+			    </select>
+		    </div>
+		    <div class="row">
+			    <label style="width: 250px">Pan model</label>
+			    <select @bind="PanModifierKey" class="input bg-dark-550 w-full">
+				    <option>None</option>
+				    <option>Shift</option>
+				    <option>Alt</option>
+			    </select>
+			    <b> + </b>
+			    <select @bind="PanMouseAction" class="input bg-dark-550 w-full">
+				    <option>None</option>
+				    <option>LeftClick</option>
+				    <option>RightClick</option>
+				    <option>MiddleClick</option>
+			    </select>
+		    </div>
+	    </div>
+    </BodyView>
+</Modal>
+
+@code
+{
+	private Modal Modal { get; set; }
+
+	private string RotateModifierKey { get; set; }
+	private string RotateMouseAction { get; set; }
+	private string PanModifierKey { get; set; }
+	private string PanMouseAction { get; set; }
+
+	protected override void OnInitialized()
+	{
+		var stringParts = Context.GetString(StateKey.ViewportRotateGesture).Split('+');
+		if (stringParts.Length == 2)
+		{
+			RotateModifierKey = stringParts[0];
+			RotateMouseAction = stringParts[1];
+		}
+		else if (stringParts.Length == 1)
+		{
+			RotateModifierKey = "None";
+			RotateMouseAction = stringParts[0];
+		}
+		else
+		{
+			throw new Exception("ViewportRotateGesture contains an invalid length");
+		}
+
+		stringParts =  Context.GetString(StateKey.ViewportPanGesture).Split('+');
+		if (stringParts.Length == 2)
+		{
+			PanModifierKey = stringParts[0];
+			PanMouseAction = stringParts[1];
+		}
+		else if (stringParts.Length == 1)
+		{
+			PanModifierKey = "None";
+			PanMouseAction = stringParts[0];
+		}
+		else
+		{
+			throw new Exception("ViewportPanGesture contains an invalid length");
+		}
+	}
+
+    public void Open()
+    {
+        AppState.IsModalOpen = true;
+        WpfService.Set3DViewportVisibility(false);
+        Modal.Open();
+    }
+
+    private void Close()
+    {
+        Modal.Close();
+        AppState.IsModalOpen = false;
+
+	    SaveChanges();
+        
+        if (AppState.Is3DViewerOpen)
+        {
+            WpfService.Set3DViewportVisibility(true);
+        }
+    }
+
+	private void SaveChanges()
+	{
+		var newViewportRotateGesture = RotateModifierKey != "None" ? RotateModifierKey + "+" + RotateMouseAction : RotateMouseAction;
+		var newViewportPanGesture = PanModifierKey != "None" ? PanModifierKey + "+" + PanMouseAction : PanMouseAction;
+
+		Context.SetString(StateKey.ViewportRotateGesture, newViewportRotateGesture);
+		Context.SetString(StateKey.ViewportPanGesture, newViewportPanGesture);
+
+		WpfService.Update3DViewportBindings(RotateModifierKey, RotateMouseAction, PanModifierKey, PanMouseAction);
+	}
+}

--- a/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewSettingsModal.razor
+++ b/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewSettingsModal.razor
@@ -13,44 +13,44 @@
 @inject AppStateService AppState
 
 <Modal @ref="Modal">
-    <HeaderView>
-        <span class="text-grey-300 flex-grow">Model viewer settings</span>
-        <span class="material-icons cursor-pointer" @onclick="Close">close</span>
-    </HeaderView>
-    <BodyView>
-	    <div class="h-full">
-		    <div class="row">
-			    <label style="width: 250px">Rotate model</label>
-			    <select @bind="RotateModifierKey" class="input bg-dark-550 w-full">
-				    <option>None</option>
-				    <option>Shift</option>
-				    <option>Alt</option>
-			    </select>
-			    <b> + </b>
-			    <select @bind="RotateMouseAction" class="input bg-dark-550 w-full">
-				    <option>None</option>
-				    <option>LeftClick</option>
-				    <option>RightClick</option>
-				    <option>MiddleClick</option>
-			    </select>
-		    </div>
-		    <div class="row">
-			    <label style="width: 250px">Pan model</label>
-			    <select @bind="PanModifierKey" class="input bg-dark-550 w-full">
-				    <option>None</option>
-				    <option>Shift</option>
-				    <option>Alt</option>
-			    </select>
-			    <b> + </b>
-			    <select @bind="PanMouseAction" class="input bg-dark-550 w-full">
-				    <option>None</option>
-				    <option>LeftClick</option>
-				    <option>RightClick</option>
-				    <option>MiddleClick</option>
-			    </select>
-		    </div>
-	    </div>
-    </BodyView>
+	<HeaderView>
+		<span class="text-grey-300 flex-grow">Model viewer settings</span>
+		<span class="material-icons cursor-pointer" @onclick="Close">close</span>
+	</HeaderView>
+	<BodyView>
+		<div class="h-full">
+			<div class="row">
+				<label style="width: 250px">Rotate model</label>
+				<select @bind="RotateModifierKey" class="input bg-dark-550 w-full">
+					<option>None</option>
+					<option>Shift</option>
+					<option>Alt</option>
+				</select>
+				<b> + </b>
+				<select @bind="RotateMouseAction" class="input bg-dark-550 w-full">
+					<option>None</option>
+					<option>LeftClick</option>
+					<option>RightClick</option>
+					<option>MiddleClick</option>
+				</select>
+			</div>
+			<div class="row">
+				<label style="width: 250px">Pan model</label>
+				<select @bind="PanModifierKey" class="input bg-dark-550 w-full">
+					<option>None</option>
+					<option>Shift</option>
+					<option>Alt</option>
+				</select>
+				<b> + </b>
+				<select @bind="PanMouseAction" class="input bg-dark-550 w-full">
+					<option>None</option>
+					<option>LeftClick</option>
+					<option>RightClick</option>
+					<option>MiddleClick</option>
+				</select>
+			</div>
+		</div>
+	</BodyView>
 </Modal>
 
 @code
@@ -64,66 +64,38 @@
 
 	protected override void OnInitialized()
 	{
-		var stringParts = Context.GetString(StateKey.ViewportRotateGesture).Split('+');
-		if (stringParts.Length == 2)
-		{
-			RotateModifierKey = stringParts[0];
-			RotateMouseAction = stringParts[1];
-		}
-		else if (stringParts.Length == 1)
-		{
-			RotateModifierKey = "None";
-			RotateMouseAction = stringParts[0];
-		}
-		else
-		{
-			throw new Exception("ViewportRotateGesture contains an invalid length");
-		}
+		RotateModifierKey = Context.GetString(StateKey.ViewportRotateModifierKey);
+		RotateMouseAction = Context.GetString(StateKey.ViewportRotateMouseAction);
+		PanModifierKey = Context.GetString(StateKey.ViewportPanModifierKey);
+		PanMouseAction = Context.GetString(StateKey.ViewportPanMouseAction);
+	}
 
-		stringParts =  Context.GetString(StateKey.ViewportPanGesture).Split('+');
-		if (stringParts.Length == 2)
+	public void Open()
+	{
+		AppState.IsModalOpen = true;
+		WpfService.Set3DViewportVisibility(false);
+		Modal.Open();
+	}
+
+	private void Close()
+	{
+		Modal.Close();
+		AppState.IsModalOpen = false;
+
+		SaveChanges();
+
+		if (AppState.Is3DViewerOpen)
 		{
-			PanModifierKey = stringParts[0];
-			PanMouseAction = stringParts[1];
-		}
-		else if (stringParts.Length == 1)
-		{
-			PanModifierKey = "None";
-			PanMouseAction = stringParts[0];
-		}
-		else
-		{
-			throw new Exception("ViewportPanGesture contains an invalid length");
+			WpfService.Set3DViewportVisibility(true);
 		}
 	}
 
-    public void Open()
-    {
-        AppState.IsModalOpen = true;
-        WpfService.Set3DViewportVisibility(false);
-        Modal.Open();
-    }
-
-    private void Close()
-    {
-        Modal.Close();
-        AppState.IsModalOpen = false;
-
-	    SaveChanges();
-        
-        if (AppState.Is3DViewerOpen)
-        {
-            WpfService.Set3DViewportVisibility(true);
-        }
-    }
-
 	private void SaveChanges()
 	{
-		var newViewportRotateGesture = RotateModifierKey != "None" ? RotateModifierKey + "+" + RotateMouseAction : RotateMouseAction;
-		var newViewportPanGesture = PanModifierKey != "None" ? PanModifierKey + "+" + PanMouseAction : PanMouseAction;
-
-		Context.SetString(StateKey.ViewportRotateGesture, newViewportRotateGesture);
-		Context.SetString(StateKey.ViewportPanGesture, newViewportPanGesture);
+		Context.SetString(StateKey.ViewportRotateModifierKey, RotateModifierKey);
+		Context.SetString(StateKey.ViewportRotateMouseAction, RotateMouseAction);
+		Context.SetString(StateKey.ViewportPanModifierKey, PanModifierKey);
+		Context.SetString(StateKey.ViewportPanMouseAction, PanMouseAction);
 
 		WpfService.Update3DViewportBindings(RotateModifierKey, RotateMouseAction, PanModifierKey, PanMouseAction);
 	}

--- a/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewV2.razor
+++ b/Flagrum.Web/Features/AssetExplorer/Previews/ModelPreviewV2.razor
@@ -5,79 +5,96 @@
 @inject JSInterop Interop
 @inject AppStateService AppState
 
-<div id="viewportContainer" class="h-full bg-grey-700 row">
-    @if (IsLoading)
-    {
-        <div class="flex flex-col items-center w-full">
-            <div class="continuous-3"></div>
-            <span class="block text-accent1-200 font-display font-bold mt-4 mr-2">Loading Model</span>
-        </div>
-    }
+<div class="flex flex-row items-center p-5 sticky top-0 z-40 bg-grey-700">
+	<div class="flex-grow"></div>
+	@if (!IsLoading)
+	{
+		<Button Icon="settings" Text="Settings" CssClass="mr-4" OnClick="OpenSettingsModal"></Button>
+	}
 </div>
+<div id="viewportContainer" class="h-full bg-grey-700 row">
+	@if (IsLoading)
+	{
+		<div class="flex flex-col items-center w-full">
+			<div class="continuous-3"></div>
+			<span class="block text-accent1-200 font-display font-bold mt-4 mr-2">Loading Model</span>
+		</div>
+	}
+</div>
+
+<ModelPreviewSettingsModal @ref="_modelPreviewSettingsModal" />
 
 @code
 {
-    [Parameter]
-    public AssetExplorerItem Item { get; set; }
+	[Parameter]
+	public AssetExplorerItem Item { get; set; }
 
-    private AssetExplorerItem _lastItem;
-    private bool _isRendered;
-    
-    private bool IsLoading { get; set; }
+	private AssetExplorerItem _lastItem;
+	private bool _isRendered;
+	private bool IsLoading { get; set; }
+	private ModelPreviewSettingsModal _modelPreviewSettingsModal;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            IsLoading = true;
-            StateHasChanged();
-            
-            await Interop.ObserveElementResize(DotNetObjectReference.Create(this), "viewportContainer");
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (firstRender)
+		{
+			IsLoading = true;
+			StateHasChanged();
 
-            var left = await Interop.GetElementLeftOffset("viewportContainer");
-            var top = await Interop.GetElementTopOffset("viewportContainer");
-            var width = await Interop.GetElementWidth("viewportContainer");
-            var height = await Interop.GetElementHeight("viewportContainer");
+			await Interop.ObserveElementResize(DotNetObjectReference.Create(this), "viewportContainer");
 
-            WpfService.Resize3DViewport((int)left, (int)top, (int)width, (int)height);
-            WpfService.Set3DViewportVisibility(true);
-            await WpfService.ChangeModel(Item.Uri);
+			var left = await Interop.GetElementLeftOffset("viewportContainer");
+			var top = await Interop.GetElementTopOffset("viewportContainer");
+			var width = await Interop.GetElementWidth("viewportContainer");
+			var height = await Interop.GetElementHeight("viewportContainer");
 
-            _lastItem = Item;
-            _isRendered = true;
-            AppState.Is3DViewerOpen = true;
+			WpfService.Resize3DViewport((int)left, (int)top, (int)width, (int)height);
+			WpfService.Set3DViewportVisibility(true);
+			await WpfService.ChangeModel(Item.Uri);
 
-            IsLoading = false;
-            StateHasChanged();
-        }
-    }
+			_lastItem = Item;
+			_isRendered = true;
+			AppState.Is3DViewerOpen = true;
 
-    protected override async Task OnParametersSetAsync()
-    {
-        if (_isRendered && Item.Uri != _lastItem.Uri)
-        {
-            IsLoading = true;
-            StateHasChanged();
-            
-            WpfService.Set3DViewportVisibility(false);
-            await WpfService.ChangeModel(Item.Uri);
-            WpfService.Set3DViewportVisibility(true);
-            _lastItem = Item;
+			IsLoading = false;
+			StateHasChanged();
+		}
+	}
 
-            IsLoading = false;
-            StateHasChanged();
-        }
-    }
+	protected override async Task OnParametersSetAsync()
+	{
+		if (_isRendered && Item.Uri != _lastItem.Uri)
+		{
+			IsLoading = true;
+			StateHasChanged();
 
-    [JSInvokable]
-    public void OnResize(double left, double top, double width, double height)
-    {
-        WpfService.Resize3DViewport((int)left, (int)top, (int)width, (int)height);
-    }
+			WpfService.Set3DViewportVisibility(false);
+			await WpfService.ChangeModel(Item.Uri);
+			WpfService.Set3DViewportVisibility(true);
+			_lastItem = Item;
 
-    public void Dispose()
-    {
-        WpfService.Set3DViewportVisibility(false);
-        AppState.Is3DViewerOpen = false;
-    }
+			IsLoading = false;
+			StateHasChanged();
+		}
+	}
+
+	[JSInvokable]
+	public void OnResize(double left, double top, double width, double height)
+	{
+		WpfService.Resize3DViewport((int)left, (int)top, (int)width, (int)height);
+	}
+
+	public void Dispose()
+	{
+		WpfService.Set3DViewportVisibility(false);
+		AppState.Is3DViewerOpen = false;
+	}
+
+	private void OpenSettingsModal()
+	{
+		if (!IsLoading)
+		{
+			_modelPreviewSettingsModal.Open();
+		}
+	}
 }

--- a/Flagrum.Web/Persistence/Entities/StatePair.cs
+++ b/Flagrum.Web/Persistence/Entities/StatePair.cs
@@ -14,8 +14,10 @@ public enum StateKey
     BinmodListPath = 5,
     LastSeenVersionNotes = 6,
     CurrentAssetExplorerPath = 7,
-    ViewportRotateGesture = 8,
-    ViewportPanGesture = 9
+    ViewportRotateModifierKey = 8,
+    ViewportRotateMouseAction = 9,
+    ViewportPanModifierKey = 10,
+    ViewportPanMouseAction = 11,
 }
 
 public class StatePair

--- a/Flagrum.Web/Persistence/Entities/StatePair.cs
+++ b/Flagrum.Web/Persistence/Entities/StatePair.cs
@@ -6,14 +6,16 @@ namespace Flagrum.Web.Persistence.Entities;
 
 public enum StateKey
 {
-    CurrentAssetNode,
-    CurrentEarcCategory,
-    Language,
-    HaveThumbnailsBeenResized,
-    GamePath,
-    BinmodListPath,
-    LastSeenVersionNotes,
-    CurrentAssetExplorerPath
+    CurrentAssetNode = 0,
+    CurrentEarcCategory = 1,
+    Language = 2,
+    HaveThumbnailsBeenResized = 3,
+    GamePath = 4,
+    BinmodListPath = 5,
+    LastSeenVersionNotes = 6,
+    CurrentAssetExplorerPath = 7,
+    ViewportRotateGesture = 8,
+    ViewportPanGesture = 9
 }
 
 public class StatePair
@@ -47,7 +49,7 @@ public static class StatePairExtensions
         var pair = context.StatePairs.FirstOrDefault(p => p.Key == key);
         if (pair == null)
         {
-            pair = new StatePair {Key = key, Value = value};
+            pair = new StatePair { Key = key, Value = value };
             context.Add(pair);
         }
         else

--- a/Flagrum.Web/Services/IWpfService.cs
+++ b/Flagrum.Web/Services/IWpfService.cs
@@ -14,4 +14,5 @@ public interface IWpfService
     void Resize3DViewport(int left, int top, int width, int height);
     void Set3DViewportVisibility(bool isVisible);
     Task ChangeModel(string gmdlUri);
+    void Update3DViewportBindings(string rotateModifierKey, string rotateMouseAction, string panModifierKey, string panMouseAction);
 }


### PR DESCRIPTION
See issue #20 

I have added a gray bar on top of the model viewer, which contains a button to open the settings menu with. This approach could lead to confusion, because in certain situations it can look like the viewer isn't correctly showing the model off (see the example below). A button floating on top of the model viewer would be a better solution, but I have no idea how to do that. An easier solution would be to change the color of the gray bar.

![image](https://user-images.githubusercontent.com/54854679/193316494-762dd81b-3226-4c3e-9ab2-4ea38cf0c7f7.png)

The settings menu allows you to change the gesture for rotating and panning a model. I didn’t add the ctrl modifier key because that key didn’t for some unknown reason.

The UI of this menu probably needs to be improved. I'm not very good with html/css though, so I hope you can do this @Kizari 😅. 
This menu needs to get an Japanese translation too.

![image](https://user-images.githubusercontent.com/54854679/193318139-cb2f5daa-dc3d-4a54-b941-8b5b0b5e593d.png)


