### PR TITLE
bug(Duplicate Mod Detection)

### DIFF
--- a/src/Flagrum.Application/Features/ModManager/Installer/FlagrumModInstaller.cs
+++ b/src/Flagrum.Application/Features/ModManager/Installer/FlagrumModInstaller.cs
@@ -80,7 +80,7 @@ public partial class FlagrumModInstaller
                 "You already have the following mods installed. If you wish to reinstall them, please " +
                 "delete the copies you already have first and try again.<br/><br/>" +
                 duplicates.Aggregate("", (previous, next) =>
-                    $"{previous}<strong>{next.Metadata.Name}</strong><br/>"));
+                    $"{previous}<strong>{_modManager.Projects[next.Metadata.Guid].Name}</strong><br/>"));
         }
 
         var result = new ModInstallationResult(ModInstallationStatus.Success);


### PR DESCRIPTION
Fix for https://github.com/Kizari/Flagrum/issues/207
Pop-up for duplicate mods was incorrectly showing the name of the mod trying to be installed instead of the mod it conflicts with that would need to be deleted.